### PR TITLE
Mark `rand` as a dev-dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ readme = "README.md"
 keywords = ["polyline", "geo"]
 license = "ISC"
 
-[dependencies]
+[dev-dependencies]
 rand = "0.5.0"


### PR DESCRIPTION
It's only used in the benchmark