### PR TITLE
Switch to criterion to enable stable benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,8 @@ edition = "2018"
 
 [dev-dependencies]
 rand = "0.5.0"
+criterion = "0.2"
+
+[[bench]]
+name = "benchmarks"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/georust/polyline"
 readme = "README.md"
 keywords = ["polyline", "geo"]
 license = "ISC"
+edition = "2018"
 
 [dev-dependencies]
 rand = "0.5.0"

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,21 +1,21 @@
-#![feature(test)]
-extern crate test;
-use test::Bencher;
+#[macro_use]
+extern crate criterion;
+use criterion::Criterion;
 use polyline::encode_coordinates;
-
-extern crate rand;
 use rand::distributions::{Distribution, Range};
 
-#[bench]
 #[allow(unused_must_use)]
-fn bench_threads(b: &mut Bencher) {
+fn bench_threads(c: &mut Criterion) {
     let num_coords = 10000;
     // These coordinates cover London, approximately
     let between_lon = Range::new(-6.379880, 1.768960);
     let between_lat = Range::new(49.871159, 55.811741);
     let mut rng = rand::thread_rng();
     let res = vec![[between_lat.sample(&mut rng), between_lon.sample(&mut rng)]; num_coords];
-    b.iter(|| {
+    c.bench_function("bench threads", move |b| b.iter(|| {
         encode_coordinates(&res, 5);
-    });
+    }));
 }
+
+criterion_group!(benches, bench_threads);
+criterion_main!(benches);

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,7 +1,6 @@
 #![feature(test)]
 extern crate test;
 use test::Bencher;
-extern crate polyline;
 use polyline::encode_coordinates;
 
 extern crate rand;


### PR DESCRIPTION
This PR switches to the 2018 edition and enables benchmarks on stable using the criterion crate.