### PR TITLE
Switch to types from geo-types crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,8 @@ edition = "2018"
 
 [dev-dependencies]
 rand = "0.5.0"
+criterion = "0.2"
+
+[[bench]]
+name = "benchmarks"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ keywords = ["polyline", "geo"]
 license = "ISC"
 edition = "2018"
 
+[dependencies]
+geo-types = "0.4.2"
+
 [dev-dependencies]
 rand = "0.5.0"
 criterion = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/georust/polyline"
 readme = "README.md"
 keywords = ["polyline", "geo"]
 license = "ISC"
+edition = "2018"
 
 [dev-dependencies]
 rand = "0.5.0"

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -3,6 +3,7 @@ extern crate criterion;
 use criterion::Criterion;
 use polyline::encode_coordinates;
 use rand::distributions::{Distribution, Range};
+use geo_types::LineString;
 
 #[allow(unused_must_use)]
 fn bench_threads(c: &mut Criterion) {
@@ -12,8 +13,9 @@ fn bench_threads(c: &mut Criterion) {
     let between_lat = Range::new(49.871159, 55.811741);
     let mut rng = rand::thread_rng();
     let res = vec![[between_lat.sample(&mut rng), between_lon.sample(&mut rng)]; num_coords];
+    let res : LineString<f64> = res.into();
     c.bench_function("bench threads", move |b| b.iter(|| {
-        encode_coordinates(&res, 5);
+        encode_coordinates(res.clone(), 5);
     }));
 }
 

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,21 +1,21 @@
-#![feature(test)]
-extern crate test;
-use test::Bencher;
+#[macro_use]
+extern crate criterion;
+use criterion::Criterion;
 use polyline::encode_coordinates;
-
-extern crate rand;
 use rand::distributions::{Distribution, Range};
 
-#[bench]
 #[allow(unused_must_use)]
-fn bench_threads(b: &mut Bencher) {
+fn bench_threads(c: &mut Criterion) {
     let num_coords = 10000;
     // These coordinates cover London, approximately
     let between_lon = Range::new(-6.379880, 1.768960);
     let between_lat = Range::new(49.871159, 55.811741);
     let mut rng = rand::thread_rng();
     let res = vec![[between_lat.sample(&mut rng), between_lon.sample(&mut rng)]; num_coords];
-    b.iter(|| {
+    c.bench_function("bench threads", move |b| b.iter(|| {
         encode_coordinates(&res, 5);
-    });
+    }));
 }
+
+criterion_group!(benches, bench_threads);
+criterion_main!(benches);

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,7 +1,6 @@
 #![feature(test)]
 extern crate test;
 use test::Bencher;
-extern crate polyline;
 use polyline::encode_coordinates;
 
 extern crate rand;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,13 +11,15 @@
 //! Encoded polyline: "_p~iF~ps|U_ulLnnqC_mqNvxq`@""
 //! ```
 //! use polyline;
+//! use geo_types::line_string;
 //!
-//! let coord = vec![[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]];
+//! let coord = line_string![(x: -120.2, y: 38.5), (x: -120.95, y: 40.7), (x: -126.453, y: 43.252)];
 //! let output = "_p~iF~ps|U_ulLnnqC_mqNvxq`@";
-//! let result = polyline::encode_coordinates(&coord, 5).unwrap();
+//! let result = polyline::encode_coordinates(coord, 5).unwrap();
 //! assert_eq!(result, output)
 //! ```
 use std::{char, cmp};
+use geo_types::{Coordinate, LineString};
 
 const MIN_LONGITUDE: f64 = -180.0;
 const MAX_LONGITUDE: f64 = 180.0;
@@ -57,42 +59,35 @@ fn encode(current: f64, previous: f64, factor: i32) -> Result<String, String> {
     Ok(output)
 }
 
-/// Encodes a Google Encoded Polyline. Accepts a slice,
-/// or anything (such as a Vec) that can deref to a slice.
+/// Encodes a Google Encoded Polyline.
 ///
 /// # Examples
 ///
 /// ```
 /// use polyline;
+/// use geo_types::line_string;
 ///
-/// let coords_vec = vec![[1.0, 2.0], [3.0, 4.0]];
-/// let encoded_vec = polyline::encode_coordinates(&coords_vec, 5).unwrap();
-///
-/// let coords_slice = [[1.0, 2.0], [3.0, 4.0]];
-/// let encoded_slice = polyline::encode_coordinates(&coords_slice, 5).unwrap();
+/// let coords = line_string![(x: 2.0, y: 1.0), (x: 4.0, y: 3.0)];
+/// let encoded_vec = polyline::encode_coordinates(coords, 5).unwrap();
 /// ```
-pub fn encode_coordinates(coordinates: &[[f64; 2]], precision: u32) -> Result<String, String> {
-    if coordinates.is_empty() {
-        return Ok("".to_string());
-    }
-    for (i, pair) in coordinates.iter().enumerate() {
-        check(pair[0], (MIN_LATITUDE, MAX_LATITUDE))
-            .map_err(|e| format!("Latitude error at position {0}: {1}", i, e).to_string())?;
-
-        check(pair[1], (MIN_LONGITUDE, MAX_LONGITUDE))
-            .map_err(|e| format!("Longitude error at position {0}: {1}", i, e).to_string())?;
-    }
+pub fn encode_coordinates<C>(coordinates: C, precision: u32) -> Result<String, String>
+where
+    C: IntoIterator<Item=Coordinate<f64>>,
+{
     let base: i32 = 10;
     let factor: i32 = base.pow(precision);
 
-    let mut output =
-        encode(coordinates[0][0], 0.0, factor)? + &encode(coordinates[0][1], 0.0, factor)?;
+    let mut output = "".to_string();
+    let mut b = Coordinate { x: 0.0, y: 0.0 };
 
-    for (i, _) in coordinates.iter().enumerate().skip(1) {
-        let a = coordinates[i];
-        let b = coordinates[i - 1];
-        output = output + &encode(a[0], b[0], factor)?;
-        output = output + &encode(a[1], b[1], factor)?;
+    for (i, a) in coordinates.into_iter().enumerate() {
+        check(a.y, (MIN_LATITUDE, MAX_LATITUDE))
+            .map_err(|e| format!("Latitude error at position {0}: {1}", i, e).to_string())?;
+        check(a.x, (MIN_LONGITUDE, MAX_LONGITUDE))
+            .map_err(|e| format!("Longitude error at position {0}: {1}", i, e).to_string())?;
+        output = output + &encode(a.y, b.y, factor)?;
+        output = output + &encode(a.x, b.x, factor)?;
+        b = a;
     }
     Ok(output)
 }
@@ -106,7 +101,7 @@ pub fn encode_coordinates(coordinates: &[[f64; 2]], precision: u32) -> Result<St
 ///
 /// let decodedPolyline = polyline::decode_polyline(&"_p~iF~ps|U_ulLnnqC_mqNvxq`@", 5);
 /// ```
-pub fn decode_polyline(polyline: &str, precision: u32) -> Result<Vec<[f64; 2]>, String> {
+pub fn decode_polyline(polyline: &str, precision: u32) -> Result<LineString<f64>, String> {
     let mut index = 0;
     let mut at_index;
     let mut lat: i64 = 0;
@@ -166,10 +161,10 @@ pub fn decode_polyline(polyline: &str, precision: u32) -> Result<Vec<[f64; 2]>, 
         lat += latitude_change;
         lng += longitude_change;
 
-        coordinates.push([lat as f64 / factor as f64, lng as f64 / factor as f64]);
+        coordinates.push([lng as f64 / factor as f64, lat as f64 / factor as f64]);
     }
 
-    Ok(coordinates)
+    Ok(coordinates.into())
 }
 
 #[cfg(test)]
@@ -177,9 +172,10 @@ mod tests {
 
     use super::decode_polyline;
     use super::encode_coordinates;
+    use geo_types::LineString;
 
     struct TestCase {
-        input: Vec<[f64; 2]>,
+        input: LineString<f64>,
         output: &'static str,
     }
 
@@ -187,17 +183,17 @@ mod tests {
     fn it_works() {
         let test_cases = vec![
             TestCase {
-                input: vec![[1.0, 2.0], [3.0, 4.0]],
+                input: vec![[2.0, 1.0], [4.0, 3.0]].into(),
                 output: "_ibE_seK_seK_seK",
             },
             TestCase {
-                input: vec![[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]],
+                input: vec![[-120.2, 38.5], [-120.95, 40.7], [-126.453, 43.252]].into(),
                 output: "_p~iF~ps|U_ulLnnqC_mqNvxq`@",
             },
         ];
         for test_case in test_cases {
             assert_eq!(
-                encode_coordinates(&test_case.input, 5).unwrap(),
+                encode_coordinates(test_case.input.clone(), 5).unwrap(),
                 test_case.output
             );
             assert_eq!(
@@ -212,7 +208,7 @@ mod tests {
     // emoji can't be decoded
     fn broken_string() {
         let s = "_p~iF~ps|U_u🗑lLnnqC_mqNvxq`@";
-        let res = vec![[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]];
+        let res = vec![[-120.2, 38.5], [-120.95, 40.7], [-126.453, 43.252]].into();
         assert_eq!(decode_polyline(&s, 5).unwrap(), res);
     }
 
@@ -221,7 +217,7 @@ mod tests {
     // Can't have a latitude > 90.0
     fn bad_coords() {
         let s = "_p~iF~ps|U_ulLnnqC_mqNvxq`@";
-        let res = vec![[38.5, -120.2], [40.7, -120.95], [430.252, -126.453]];
-        assert_eq!(encode_coordinates(&res, 5).unwrap(), s);
+        let res : LineString<f64> = vec![[-120.2, 38.5], [-120.95, 40.7], [-126.453, 430.252]].into();
+        assert_eq!(encode_coordinates(res, 5).unwrap(), s);
     }
 }


### PR DESCRIPTION
This PR switches the encode/decode API to use the `Coordinate` and `LineString` types from the geo-types crate and should fix #13.

As this is my first PR for such a switch it might not be idiomatic. So I'm looking for feedback. The benchmarks and tests now include a `.clone()` for the input, because the iterator now owns the provided coordinates, instead of references to `f64` pairs. Is there a way around this? Is this ok?

This PR also contains #15 and #17.