### PR TITLE
Fix rounding errors with coordinates close to each other

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,10 @@ where
 }
 
 fn encode(current: f64, previous: f64, factor: i32) -> Result<String, String> {
-    let mut coordinate = (scale(current, factor) - scale(previous, factor)) << 1;
-    if (current - previous) < 0.0 {
+    let current = scale(current, factor);
+    let previous = scale(previous, factor);
+    let mut coordinate = (current - previous) << 1;
+    if (current - previous) < 0 {
         coordinate = !coordinate;
     }
     let mut output: String = "".to_string();
@@ -205,6 +207,21 @@ mod tests {
                 test_case.input
             );
         }
+    }
+
+    #[test]
+    // coordinates close to each other (below precision) should work
+    fn rounding_error() {
+        let poly = "cr_iI}co{@?dB";
+        let res = vec![[54.0702648, 9.9131118], [54.0702578, 9.9126013]];
+        assert_eq!(
+            encode_coordinates(&res, 5).unwrap(),
+            poly
+        );
+        assert_eq!(
+            decode_polyline(&poly, 5).unwrap(),
+            vec![[54.07026, 9.91311], [54.07026, 9.91260]]
+        );
     }
 
     #[test]


### PR DESCRIPTION
This adds a test and fix for a rounding error condition, when two coordinates are very close to each other, so that the difference is below precision.

The current implementation would produce wrong characters, because the sign of the original subtraction would differ from the rounded subtraction.

This PR changes the comparison to just use the sign of the rounded subtraction, see [polyline.js](https://github.com/mapbox/polyline/blob/master/src/polyline.js#L19-L26) for comparison.