### PR TITLE
Update geo-types version requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.9.0
+* Update `geo-types` dependency to allow for 0.6 or 0.7
+
 ## 0.8.0
 * Bump geo-types dependency to 0.6
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-geo-types = "0.6"
+geo-types = ">=0.6, <0.8"
 
 [dev-dependencies]
 rand = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "polyline"
 description = "Encoder and decoder for the Google Encoded Polyline format"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Tom MacWright <tom@macwright.org>", "The GeoRust Developers"]
 repository = "https://github.com/georust/polyline"
 readme = "README.md"


### PR DESCRIPTION
Allows for using 0.6 or 0.7 since this is using `f64` for all coordinates and it doesn't look like there are any compatibility issues