### PR TITLE
Prepare for 0.10.0 (breaking) release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.10.0
 
+* BREAKING: update to geo-types 0.7.8, drop support for geo-types 0.6
 * Update Coordinates to Coord due to geo-types change
 * Apply clippy suggestions
 * Update dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-geo-types = ">=0.6, <0.8"
+geo-types = "0.7.8"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ Google Encoded Polyline encoding & decoding in Rust.
 
 ## A Note on Coordinate Order
 
-This crate uses `Coordinate` and `LineString` types from the `geo-types` crate, which encodes coordinates in `(x, y)` order. The Polyline algorithm and first-party documentation assumes the _opposite_ coordinate order. It is thus advisable to pay careful attention to the order of the coordinates you use for encoding and decoding.
+This crate uses `Coord` and `LineString` types from the `geo-types` crate, which encodes coordinates in `(x, y)` order. The Polyline algorithm and first-party documentation assumes the _opposite_ coordinate order. It is thus advisable to pay careful attention to the order of the coordinates you use for encoding and decoding.
 
 [Documentation](https://docs.rs/polyline/)

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -33,7 +33,7 @@ fn bench_decode(c: &mut Criterion) {
     let mut v: Vec<[f64; 2]> = vec![];
     (0..21501).for_each(|_| v.push([between_lon.sample(&mut rng), between_lat.sample(&mut rng)]));
     let res: LineString<f64> = v.into();
-    let encoded = encode_coordinates(res.clone(), 6).unwrap();
+    let encoded = encode_coordinates(res, 6).unwrap();
     c.bench_function("bench decode: 21502 coordinates", move |b| {
         b.iter(|| {
             decode_polyline(&encoded, 6);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@ mod tests {
         let res: LineString<f64> = vec![[9.9131118, 54.0702648], [9.9126013, 54.0702578]].into();
         assert_eq!(encode_coordinates(res, 5).unwrap(), poly);
         assert_eq!(
-            decode_polyline(&poly, 5).unwrap(),
+            decode_polyline(poly, 5).unwrap(),
             vec![[9.91311, 54.07026], [9.91260, 54.07026]].into()
         );
     }


### PR DESCRIPTION
854612f917e0d54746a6357e250131b0a1d76a28 switched from the deprecated geo_types::Coordinate -> geo_types::Coord. Since Coord didn't exist until geo-types 0.7.8, we have to drop support for older versions, which is a breaking change in this case since we used to support geo-types 0.6
