### PR TITLE
Prepare for 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Changelog
 
+## 0.10.1
+
+* Fix dependencies to officially drop geo-types 0.6 - it was already
+  effectively dropped with the bump to 0.10.0 (it wouldn't compile), so this
+  isn't an additionally breaking change.
+
 ## 0.10.0
 
-* BREAKING: update to geo-types 0.7.8, drop support for geo-types 0.6
 * Update Coordinates to Coord due to geo-types change
+  * This is a BREAKING change for geo-types 0.6 users
 * Apply clippy suggestions
 * Update dependencies
 * Refactor decoding logic for perf improvement (https://github.com/georust/polyline/pull/28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.10.0
 
+* BREAKING: update to geo-types 0.7.8, drop support for geo-types 0.6
 * Update Coordinates to Coord due to geo-types change
 * Apply clippy suggestions
 * Update dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-geo-types = ">=0.6, <0.8"
+geo-types = "0.7.8"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "polyline"
 description = "Encoder and decoder for the Google Encoded Polyline format"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Tom MacWright <tom@macwright.org>", "The GeoRust Developers <mods@georust.org>"]
 repository = "https://github.com/georust/polyline"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ Google Encoded Polyline encoding & decoding in Rust.
 
 ## A Note on Coordinate Order
 
-This crate uses `Coordinate` and `LineString` types from the `geo-types` crate, which encodes coordinates in `(x, y)` order. The Polyline algorithm and first-party documentation assumes the _opposite_ coordinate order. It is thus advisable to pay careful attention to the order of the coordinates you use for encoding and decoding.
+This crate uses `Coord` and `LineString` types from the `geo-types` crate, which encodes coordinates in `(x, y)` order. The Polyline algorithm and first-party documentation assumes the _opposite_ coordinate order. It is thus advisable to pay careful attention to the order of the coordinates you use for encoding and decoding.
 
 [Documentation](https://docs.rs/polyline/)

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -33,7 +33,7 @@ fn bench_decode(c: &mut Criterion) {
     let mut v: Vec<[f64; 2]> = vec![];
     (0..21501).for_each(|_| v.push([between_lon.sample(&mut rng), between_lat.sample(&mut rng)]));
     let res: LineString<f64> = v.into();
-    let encoded = encode_coordinates(res.clone(), 6).unwrap();
+    let encoded = encode_coordinates(res, 6).unwrap();
     c.bench_function("bench decode: 21502 coordinates", move |b| {
         b.iter(|| {
             decode_polyline(&encoded, 6);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@ mod tests {
         let res: LineString<f64> = vec![[9.9131118, 54.0702648], [9.9126013, 54.0702578]].into();
         assert_eq!(encode_coordinates(res, 5).unwrap(), poly);
         assert_eq!(
-            decode_polyline(&poly, 5).unwrap(),
+            decode_polyline(poly, 5).unwrap(),
             vec![[9.91311, 54.07026], [9.91260, 54.07026]].into()
         );
     }


### PR DESCRIPTION
supersedes #31 

Ideally this would have been included in the v0.10.0 release, since the project no longer builds with geo-types 0.6, but I didn't realize v0.10.0 had already been published.

I'm doing a bit of slippery semver lawyering here on this subsequent release, saying that even though we're officially bumping the geo-types version, which is normally a breaking change, in this case it's not *newly* breaking things for anyone - because those people (if they exist) would have had their builds break when upgrading to v0.10.0, and if they got v0.10.0 building, they'll need no further changes to use this release.

p.s. could you push a v0.10.0 tag please @urschrei?