### PR TITLE
speed up encode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Speed up encode function (now runs in ~72% less time / 3.5x improvement):
+  * https://github.com/georust/polyline/pull/42
+
 ## 0.10.2
 
 * fix decoder crashing with out-of-bounds error (https://github.com/georust/polyline/pull/37):

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,73 +1,66 @@
 #[macro_use]
 extern crate criterion;
-use criterion::Criterion;
+use criterion::{Criterion, black_box};
 use geo_types::LineString;
 use polyline::{decode_polyline, encode_coordinates};
 use rand::distributions::Distribution;
 use rand::distributions::Uniform;
-use rand::thread_rng;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
 
 #[allow(unused_must_use)]
 fn bench_encode(c: &mut Criterion) {
-    let mut rng = thread_rng();
+    let mut rng = StdRng::seed_from_u64(42);
     // These coordinates cover London, approximately
     let between_lon = Uniform::from(-6.379880..1.768960);
     let between_lat = Uniform::from(49.871159..55.811741);
     let mut v: Vec<[f64; 2]> = vec![];
-    (0..1000).for_each(|_| v.push([between_lon.sample(&mut rng), between_lat.sample(&mut rng)]));
+    (0..10_000).for_each(|_| v.push([between_lon.sample(&mut rng), between_lat.sample(&mut rng)]));
     let res: LineString<f64> = v.into();
-    c.bench_function("bench encode: 1000 coordinates", move |b| {
+
+    c.bench_function("encode 10_000 coordinates at precision 1e-5", |b| {
         b.iter(|| {
-            encode_coordinates(res.clone(), 5);
+            black_box(encode_coordinates(res.coords().copied(), 5));
+        })
+    });
+
+    c.bench_function("encode 10_000 coordinates at precision 1e-6", |b| {
+        b.iter(|| {
+            black_box(encode_coordinates(res.coords().copied(), 6));
         })
     });
 }
 
 #[allow(unused_must_use)]
 fn bench_decode(c: &mut Criterion) {
-    // comparable cpp (see e.g. Valhalla) decodes the same number of coords in around 500 µs
-    let mut rng = thread_rng();
+    // comparable cpp (see e.g. Valhalla)
+    let mut rng = StdRng::seed_from_u64(42);
     // These coordinates cover London, approximately
     let between_lon = Uniform::from(-6.379880..1.768960);
     let between_lat = Uniform::from(49.871159..55.811741);
     let mut v: Vec<[f64; 2]> = vec![];
-    (0..21501).for_each(|_| v.push([between_lon.sample(&mut rng), between_lat.sample(&mut rng)]));
+    (0..10_000).for_each(|_| v.push([between_lon.sample(&mut rng), between_lat.sample(&mut rng)]));
     let res: LineString<f64> = v.into();
     let encoded = encode_coordinates(res, 6).unwrap();
-    c.bench_function("bench decode: 21502 coordinates", move |b| {
+
+    c.bench_function("decode 10_000 coordinates at precision 1e-5", |b| {
         b.iter(|| {
-            decode_polyline(&encoded, 6);
+            black_box(decode_polyline(&encoded, 5));
+        })
+    });
+
+    c.bench_function("decode 10_000 coordinates at precision 1e-6", |b| {
+        b.iter(|| {
+            black_box(decode_polyline(&encoded, 6));
         })
     });
 }
 
-#[allow(unused_must_use)]
-fn bench_polyline6_decoding(c: &mut Criterion) {
-    c.bench_function("bench polyline6 decoding", move |b| {
-        b.iter(|| {
-            decode_polyline("_p~iF~ps|U_ulLnnqC_mqNvxq`@", 6).unwrap();
-        })
-    });
-}
-
-#[allow(unused_must_use)]
-fn bench_polyline6_decoding_huge(c: &mut Criterion) {
-    c.bench_function("bench HUGE polyline6 decoding", move |b| {
-        b.iter(|| {
-            decode_polyline(
-                include_str!("../resources/route-geometry-sweden-west-coast.polyline6"),
-                6,
-            )
-            .unwrap();
-        })
-    });
-}
 
 criterion_group!(
     benches,
     bench_encode,
     bench_decode,
-    bench_polyline6_decoding,
-    bench_polyline6_decoding_huge
 );
 criterion_main!(benches);


### PR DESCRIPTION
- **attempt to make bench more deterministic**
- **[perf] mutate rather than allocate a bunch of heap strings**

```
    encode 10_000 coordinates at precision 1e-5
                            time:   [123.68 µs 123.80 µs 123.94 µs]
                            change: [-74.528% -74.461% -74.401%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 6 outliers among 100 measurements (6.00%)
      4 (4.00%) high mild
      2 (2.00%) high severe

    encode 10_000 coordinates at precision 1e-6
                            time:   [136.60 µs 137.55 µs 138.55 µs]
                            change: [-73.205% -73.066% -72.932%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 11 outliers among 100 measurements (11.00%)
      9 (9.00%) high mild
      2 (2.00%) high severe
```