### PR TITLE
flexpolyline bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ geo-types = "0.7.8"
 [dev-dependencies]
 rand = "0.8.5"
 criterion = "0.5.1"
+flexpolyline = "0.1.0"
 
 [[bench]]
 name = "benchmarks"


### PR DESCRIPTION
**update: merged!** ~~Based on #45, so merge that first (Sorry for the long chain of PR's. )~~

FIXES #35 

(actually it just demonstrates that it's been addressed by previous work by me and @mattiZed)

flexpolyline is 20% slower for encode
```
encode 10_000 coordinates at precision 1e-5
                        time:   [105.71 µs 105.83 µs 105.97 µs]

encode 10_000 coordinates at precision 1e-5 (flexpolyline)
                        time:   [126.90 µs 127.64 µs 128.37 µs]
```

flexpolyline is 12% slower for decode
```
decode 10_000 coordinates at precision 1e-5
                        time:   [88.922 µs 89.823 µs 90.648 µs]

decode 10_000 coordinates at precision 1e-5 (flexpolyline)
                        time:   [99.103 µs 100.57 µs 102.29 µs]
```

These aren't very rigorous benchmarks. In fact, I'd be OK with not merging them at all, but it might be a good thing to keep around in case we break something and become 10x slower than flexpolyline.