### PR TITLE
Switch to structured errors, inline encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ geo-types = "0.7.8"
 rand = "0.8.5"
 criterion = "0.5.1"
 
+[lib]
+bench = false
+
 [[bench]]
 name = "benchmarks"
 harness = false

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,33 @@
+use std::fmt::Write;
+
+#[derive(Debug, PartialEq)]
+#[non_exhaustive]
+pub enum PolylineError {
+    LongitudeCoordError { coord: f64, idx: usize },
+    LatitudeCoordError { coord: f64, idx: usize },
+    NoLongError { idx: usize },
+    DecodeError { idx: usize },
+    DecodeCharError,
+}
+
+impl std::error::Error for PolylineError {}
+impl std::fmt::Display for PolylineError {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let mut s = String::new();
+        match self {
+            PolylineError::LongitudeCoordError { coord, idx } => {
+                write!(&mut s, "Invalid longitude: {} at position {}", coord, idx)
+            }
+            PolylineError::LatitudeCoordError { coord, idx } => {
+                write!(&mut s, "Invalid latitude: {} at position {}", coord, idx)
+            }
+            PolylineError::DecodeError { idx } => {
+                write!(&mut s, "Cannot decode character at index {}", idx)
+            }
+            PolylineError::NoLongError { idx } => {
+                write!(&mut s, "No longitude to go with latitude at index: {}", idx)
+            }
+            PolylineError::DecodeCharError => write!(&mut s, "Couldn't decode character"),
+        }
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,3 @@
-use std::fmt::Write;
-
 #[derive(Debug, PartialEq)]
 #[non_exhaustive]
 pub enum PolylineError {
@@ -12,22 +10,21 @@ pub enum PolylineError {
 
 impl std::error::Error for PolylineError {}
 impl std::fmt::Display for PolylineError {
-    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let mut s = String::new();
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             PolylineError::LongitudeCoordError { coord, idx } => {
-                write!(&mut s, "Invalid longitude: {} at position {}", coord, idx)
+                write!(f, "Invalid longitude: {} at position {}", coord, idx)
             }
             PolylineError::LatitudeCoordError { coord, idx } => {
-                write!(&mut s, "Invalid latitude: {} at position {}", coord, idx)
+                write!(f, "Invalid latitude: {} at position {}", coord, idx)
             }
             PolylineError::DecodeError { idx } => {
-                write!(&mut s, "Cannot decode character at index {}", idx)
+                write!(f, "Cannot decode character at index {}", idx)
             }
             PolylineError::NoLongError { idx } => {
-                write!(&mut s, "No longitude to go with latitude at index: {}", idx)
+                write!(f, "No longitude to go with latitude at index: {}", idx)
             }
-            PolylineError::DecodeCharError => write!(&mut s, "Couldn't decode character"),
+            PolylineError::DecodeCharError => write!(f, "Couldn't decode character"),
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,10 +1,28 @@
+//! Errors that can occur during encoding / decoding of Polylines
+
 #[derive(Debug, PartialEq)]
 #[non_exhaustive]
 pub enum PolylineError {
-    LongitudeCoordError { coord: f64, idx: usize },
-    LatitudeCoordError { coord: f64, idx: usize },
-    NoLongError { idx: usize },
-    DecodeError { idx: usize },
+    LongitudeCoordError {
+        /// The coordinate value that caused the error due to being outside the range `-180.0..180.0`
+        coord: f64,
+        /// The string index of the coordinate error
+        idx: usize,
+    },
+    LatitudeCoordError {
+        /// The coordinate value that caused the error due to being outside the range `-90.0..90.0`
+        coord: f64,
+        /// The string index of the coordinate error
+        idx: usize,
+    },
+    NoLongError {
+        /// The string index of the missing longitude
+        idx: usize,
+    },
+    DecodeError {
+        /// The string index of the character that caused the decoding error
+        idx: usize,
+    },
     DecodeCharError,
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -31,18 +31,18 @@ impl std::fmt::Display for PolylineError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             PolylineError::LongitudeCoordError { coord, idx } => {
-                write!(f, "Invalid longitude: {} at position {}", coord, idx)
+                write!(f, "invalid longitude: {} at position {}", coord, idx)
             }
             PolylineError::LatitudeCoordError { coord, idx } => {
-                write!(f, "Invalid latitude: {} at position {}", coord, idx)
+                write!(f, "invalid latitude: {} at position {}", coord, idx)
             }
             PolylineError::DecodeError { idx } => {
-                write!(f, "Cannot decode character at index {}", idx)
+                write!(f, "cannot decode character at index {}", idx)
             }
             PolylineError::NoLongError { idx } => {
-                write!(f, "No longitude to go with latitude at index: {}", idx)
+                write!(f, "no longitude to go with latitude at index: {}", idx)
             }
-            PolylineError::DecodeCharError => write!(f, "Couldn't decode character"),
+            PolylineError::DecodeCharError => write!(f, "couldn't decode character"),
         }
     }
 }


### PR DESCRIPTION
This PR switches to "real" structured errors, and inlines an encoding step. Perf compared to current `main`:

```shell
encode 10_000 coordinates at precision 1e-5
                        time:   [176.72 µs 177.11 µs 177.57 µs]
                        change: [-7.9523% -7.6511% -7.3754%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

encode 10_000 coordinates at precision 1e-6
                        time:   [207.34 µs 207.55 µs 207.81 µs]
                        change: [-4.6981% -4.4789% -4.1689%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  4 (4.00%) high mild
  9 (9.00%) high severe

decode 10_000 coordinates at precision 1e-5
                        time:   [101.06 µs 101.53 µs 102.02 µs]
                        change: [-34.622% -34.329% -34.044%] (p = 0.00 < 0.05)
                        Performance has improved.

decode 10_000 coordinates at precision 1e-6
                        time:   [120.94 µs 121.46 µs 122.02 µs]
                        change: [-30.601% -30.360% -30.095%] (p = 0.00 < 0.05)
                        Performance has improved.
```

The inlining improves encoding perf. _Without_ inlining, the change to structured errors improves **decoding** perf as above, but regresses **encoding** perf by 10 - 12 %.

Please feel free to bikeshed the `Error` impl: I usually use thiserror for everything but since this crate doesn't depend on `geo` I didn't want to introduce another dependency.




