### PR TITLE
Skip intermediate coord representation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,10 +146,10 @@ pub fn decode_polyline(polyline: &str, precision: u32) -> Result<LineString<f64>
             });
         }
 
-        coordinates.push([lon, lat]);
+        coordinates.push(Coord { x: lon, y: lat });
     }
 
-    Ok(coordinates.into())
+    Ok(LineString::new(coordinates))
 }
 
 fn decode_next(


### PR DESCRIPTION
We can just build up the coords directly rather than building up arrays and then converting them to Coords.

One more little perf boost. I tried this change previously, but it was causing a surprising regression in the `encode` benchmarks (even though this only touches a decode code path). 

My suspicion is that it was the same perf cliff in #48. I really don't know, but I'm imaging some incidental code layout thing that I was on the edge of. Now that that we've dived off that cliff anyway, this seems like strictly a (small) improvement.

```
$ cargo bench --bench="*" --  --baseline=sha-6872788
   Compiling polyline v0.10.2 (/Users/mkirk/src/georust/polyline)
    Finished `bench` profile [optimized] target(s) in 0.94s
     Running benches/benchmarks.rs
(target/release/deps/benchmarks-8b91c88197106af3)
encode 10_000 coordinates at precision 1e-5
                        time:   [180.56 µs 180.85 µs 181.16 µs]
                        change: [-1.3886% -1.0790% -0.7773%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild

encode 10_000 coordinates at precision 1e-6
                        time:   [219.72 µs 220.82 µs 221.84 µs]
                        change: [+0.5301% +1.0508% +1.5979%] (p = 0.00 < 0.05)
                        Change within noise threshold.

decode 10_000 coordinates at precision 1e-5
                        time:   [80.937 µs 81.828 µs 82.713 µs]
                        change: [-4.9284% -3.9764% -2.9753%] (p = 0.00 < 0.05)
                        Performance has improved.

decode 10_000 coordinates at precision 1e-6
                        time:   [97.706 µs 98.786 µs 99.825 µs]
                        change: [-3.1947% -2.2649% -1.3617%] (p = 0.00 < 0.05)
                        Performance has improved.
```
