### PR TITLE
Making operations generic over CoordFloat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "polyline"
 description = "Encoder and decoder for the Google Encoded Polyline format"
-version = "0.11.0"
+version = "0.12.0"
 repository = "https://github.com/georust/polyline"
 documentation = "https://docs.rs/polyline/"
 readme = "README.md"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,19 +1,20 @@
 //! Errors that can occur during encoding / decoding of Polylines
 
-use geo_types::Coord;
+use std::any::type_name;
+use geo_types::{Coord, CoordFloat};
 
 #[derive(Debug, PartialEq)]
 #[non_exhaustive]
-pub enum PolylineError {
+pub enum PolylineError<T: CoordFloat> {
     LongitudeCoordError {
         /// The coordinate value that caused the error due to being outside the range `-180.0..180.0`
-        coord: f64,
+        coord: T,
         /// The string index of the coordinate error
         idx: usize,
     },
     LatitudeCoordError {
         /// The coordinate value that caused the error due to being outside the range `-90.0..90.0`
-        coord: f64,
+        coord: T,
         /// The string index of the coordinate error
         idx: usize,
     },
@@ -27,21 +28,24 @@ pub enum PolylineError {
     },
     EncodeToCharError,
     CoordEncodingError {
-        coord: Coord<f64>,
+        coord: Coord<T>,
         /// The array index of the coordinate error
         idx: usize,
     },
+    /// Unable to convert a value to the desired type
+    // TODO: Decide what info we want to express here
+    NumericCastFailure
 }
 
-impl std::error::Error for PolylineError {}
-impl std::fmt::Display for PolylineError {
+impl<T: CoordFloat> std::error::Error for PolylineError<T> {}
+impl<T: CoordFloat> std::fmt::Display for PolylineError<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             PolylineError::LongitudeCoordError { coord, idx } => {
-                write!(f, "longitude out of bounds: {} at position {}", coord, idx)
+                write!(f, "longitude out of bounds: {:?} at position {}", coord, idx)
             }
             PolylineError::LatitudeCoordError { coord, idx } => {
-                write!(f, "latitude out of bounds: {} at position {}", coord, idx)
+                write!(f, "latitude out of bounds: {:?} at position {}", coord, idx)
             }
             PolylineError::DecodeError { idx } => {
                 write!(f, "cannot decode character at index {}", idx)
@@ -56,6 +60,9 @@ impl std::fmt::Display for PolylineError {
                     "the coordinate {:?} at index: {} could not be encoded",
                     coord, idx
                 )
+            },
+            PolylineError::NumericCastFailure => {
+                write!(f, "number is not representable as type {}", type_name::<T>())
             }
         }
     }


### PR DESCRIPTION
This library is not currently usable unless your geometry uses `f64` coordinates.

It's arguable whether most projects should use `f32` (IIUC most CPUs will still use 64-bit registers for 32-bit floating point math), but I think there is some value in considering support. If you are working with extremely large datasets in memory and don't need millimeter-level precision, `f32` can save a ton of RAM, enabling you to work with even larger datasets. It also *might* enable better better SIMD optimizations in the future, since you can pack twice as much data in registers.

I'm opening this as a draft PR since there are a few open questions, including whether this is even a welcome change :) This is just a first whack at a *working* implementation that shows it's possible, but we probably want to do the following before merge:

- [ ] Performance testing to make sure this doesn't regress (shouldn't, but want to make sure). I see there are criterion benchmarks, but it doesn't look like they actually run in CI? Is there a strategy for approaching things like this within the project already?
- [ ] Figure out a better approach to testing than copy+paste. I can think of a macro that generates tests for multiple types... ideas welcome.