### PR TITLE
make PolylineError clonable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+* Derive `Clone` for `PolyLineError`
+  * https://github.com/georust/polyline/pull/54
+
 ## 0.11.0
 
 * Speed up encode function (now runs in ~72% less time / 3.5x improvement):

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,7 +2,7 @@
 
 use geo_types::Coord;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[non_exhaustive]
 pub enum PolylineError {
     LongitudeCoordError {


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---

Mostly because "why not", but specifically so I can use it with thiserror `#[from]`, e.g.

```rust
#[derive(Debug, Error, Clone, PartialEq)]
enum MyError {
    #[error("Polyline error: {0}")]
    Polyline(#[from] PolylineError)
    #[error("Foo error: {0}")]
    Foo(#[from] FooError)
}
```